### PR TITLE
Tuned up calibration instructions & tweaked openScreen accordingly

### DIFF
--- a/SupportFunctions/Utils/calibDisplay_pldaps.m
+++ b/SupportFunctions/Utils/calibDisplay_pldaps.m
@@ -14,12 +14,24 @@ function [simpleGamma, measInt, measCie, lvlSet] = calibDisplay_pldaps(p, mode)
 %  Must be run after pausing a running PLDAPS session.
 %  - This is a feature, not a bug, because it ensures that measurements are made under
 %    the exact same setup conditions as your experiment.
-%  - This is not the stereo-specific version of the calibration code
+%  This is not the stereo-specific version of the calibration code
 %    - its *not* INcompatible with stereo displays, but it doesn't make/fit
 %      separate monocular calibrations, or do any binocular crosstalk measurements
 % 
+%  When making initial calibration measurements, its important to be sure that 
+%  all other/prior calibrations are disabled when the new measurements are made.
+%  - e.g. linearization via gamma table or power, or binocular crosstalk corrections
+%  - Otherwise the result will be confounded by [unknown] prior display corrections
+%  - Easiest way to do this is to make sure the .display.gamma.power field is empty
+%    before your code executes p.run
+%  - In the modularDemo, you would want to set:  pss.display.gamma.power = [];
+%  
 %  Save the returned greyscale [simpleGamma] value in your rigPrefs as:
 %       .display.gamma.power
+% 
+%  AFTER you've run your calibration & added the results to your rigPrefs,
+%  run this calibration function again to validate. This will help ensure that your
+%  validation is performed in EXACTLY the same state as your experiment.
 % 
 % 
 % EXAMPLE:
@@ -43,6 +55,7 @@ function [simpleGamma, measInt, measCie, lvlSet] = calibDisplay_pldaps(p, mode)
 %   % [ follow command window instructions to apply & save new rigPrefs values ]
 % 
 %   % Done! Future experiments on this rig will apply this gamma correction automatically
+%   % Rerun the calibration measurements with the new settings applied to validate your results
 % ---
 % 
 % 

--- a/SupportFunctions/Utils/calibDisplay_pldapsRb3d.m
+++ b/SupportFunctions/Utils/calibDisplay_pldapsRb3d.m
@@ -19,8 +19,20 @@ function [simpleGamma, measInt, measCie, lvlSet] = calibDisplay_pldapsRb3d(p, mo
 %    & binocular crosstalk correction
 %  - ...still needs [more] commenting & explanation on how to properly use/implement (TBC 2021)
 % 
+%  When making initial calibration measurements, its important to be sure that 
+%  all other/prior calibrations are disabled when the new measurements are made.
+%  - e.g. linearization via gamma table or power, or binocular crosstalk corrections
+%  - Otherwise the result will be confounded by [unknown] prior display corrections
+%  - Easiest way to do this is to make sure the .display.gamma.power field is empty
+%    before your code executes p.run
+%  - In the modularDemo, you would want to set:  pss.display.gamma.power = [];
+%  
 %  Save the returned greyscale [simpleGamma] value in your rigPrefs as:
 %       .display.gamma.power
+% 
+%  AFTER you've run your calibration & added the results to your rigPrefs,
+%  run this calibration function again to validate. This will help ensure that your
+%  validation is performed in EXACTLY the same state as your experiment.
 % 
 % 
 % EXAMPLE:
@@ -43,6 +55,7 @@ function [simpleGamma, measInt, measCie, lvlSet] = calibDisplay_pldapsRb3d(p, mo
 %   % [ follow command window instructions to apply & save new rigPrefs values ]
 %   
 %   % Done! Future experiments on this rig will apply this gamma correction automatically
+%   % Rerun the calibration measurements with the new settings applied to validate your results
 % ---
 % 
 % 

--- a/tutorial/+modularDemo/doRfPos_gabGrid.m
+++ b/tutorial/+modularDemo/doRfPos_gabGrid.m
@@ -107,7 +107,7 @@ pss.display.useOverlay = 1;
 % pss.display.screenSize = [];
 % pss.display.scrnNum = 0;
 
-pss.display.stereoMode = 4; % 0==mono 2D; 3-or-4==freeFuse 3D;  See Screen('OpenWindow?')
+pss.display.stereoMode = 0; % 0==mono 2D; 3-or-4==freeFuse 3D;  See Screen('OpenWindow?')
 
 pss.display.useGL = 1;
 pss.display.multisample = 2;


### PR DESCRIPTION
Tuned up display calibration instructions & tweaked openScreen so that
.display.gamma could be manually overridden without messing with rigPrefs directly
- for some reason, merely setting .display.gamma = [] wasn't actually overriding
existing .display.gamma.power values
- updated precidence in openScreen and instructions in calibDisplay_...m to explain
how & why those must be overridden during calibration