### PR TITLE
Update to pds.sound.stop to deactivate all sounds if called with no input argument

### DIFF
--- a/+pds/+eyelink/calibrate.m
+++ b/+pds/+eyelink/calibrate.m
@@ -14,7 +14,6 @@ function p=calibrate(p)
 %                 Added .trialSetup of reward structures to prevent error (via pds.behavior.reward.trialSetup)
 % 
        
-
 if ~isfield(p.trial.eyelink, 'fixdotW')
     p.trial.eyelink.fixdotW = ceil(0.2 * p.trial.display.ppd);
 end
@@ -24,10 +23,14 @@ if isempty(p.trial.behavior.reward.timeReward)
     pds.behavior.reward.trialSetup(p);
 end
 
+
 commandwindow;
-if p.trial.sound.use
-    Beeper
-end
+
+
+%if p.trial.sound.use
+%    Beeper
+%end
+
 disp('*************************************')
 disp('Beginning Eyelink Toolbox Calibration')
 disp('*************************************')

--- a/+pds/+sound/stop.m
+++ b/+pds/+sound/stop.m
@@ -1,16 +1,31 @@
 function stop(p, sound_name)
 % funtion pds.sound.stop(p, sound_name)
-% 
+%
 % Stop the sound associated with sound_name.
 %   - No arguments out
 %
 % 2020-01-16  TBC  Migrated to pds.sound (from pds.audio) to be consistent with field name
-% 
-%  Virtual device handle
-[~,name] = fileparts(p.trial.sound.wavfiles.(sound_name));
-pahandle = p.trial.sound.(name);
+% 2022-02-25  LPL (ll2833@columbia.edu) added functionality to deactivate
+% all sounds if function called with one input argument (pldaps object).
+%
 
-%  Stop the requested sound
-PsychPortAudio('Stop',pahandle);
+if(nargin==1)
+    names = fieldnames(p.trial.sound);
+    for i=1:numel(names)
+        pahandle = p.trial.sound.(names{i});
+        status = PsychPortAudio('getStatus',pahandle);
+        if(status.Active~=0)
+            PsychPortAudio('Stop',pahandle);
+        end
+    end
+else
+    
+    %  Virtual device handle
+    [~,name] = fileparts(p.trial.sound.wavfiles.(sound_name));
+    pahandle = p.trial.sound.(name);
+    
+    %  Stop the requested sound
+    PsychPortAudio('Stop',pahandle);
 end
 
+end

--- a/+pds/+sound/stop.m
+++ b/+pds/+sound/stop.m
@@ -6,13 +6,14 @@ function stop(p, sound_name)
 %
 % 2020-01-16  TBC  Migrated to pds.sound (from pds.audio) to be consistent with field name
 % 2022-02-25  LPL (ll2833@columbia.edu) added functionality to deactivate
-% all sounds if function called with one input argument (pldaps object).
+% all sounds if function called with one input argument.
 %
 
 if(nargin==1)
-    names = fieldnames(p.trial.sound);
-    for i=1:numel(names)
-        pahandle = p.trial.sound.(names{i});
+    fields = fieldnames(p.trial.sound.wavfiles);
+    for i=1:numel(fields)
+        [~,name] = fileparts(p.trial.sound.wavfiles.(fields{i}));
+        pahandle = p.trial.sound.(name);
         status = PsychPortAudio('getStatus',pahandle);
         if(status.Active~=0)
             PsychPortAudio('Stop',pahandle);


### PR DESCRIPTION
Main change here is adding functionality to pds.sound.stop so that it can be called without input argument and turn off all sounds.  

Beeper is depcrecated PTB function and on my system was causing a memory leak, so I commented out that code.